### PR TITLE
Add divice CRUD usecase

### DIFF
--- a/backend/internal/usecase/repository/device.go
+++ b/backend/internal/usecase/repository/device.go
@@ -7,6 +7,26 @@ import (
 	"github.com/Fumiya-Tahara/uecs-navi.git/internal/infrastructure/orm/mysqlc"
 )
 
+type JoinedDevice struct {
+	ID          int
+	HouseID     int
+	SetPoint    int
+	Duration    int
+	ClimateData string
+	Unit        string
+}
+
+func NewJoinedDevice(id, houseID, setPoint, duration int, climateData, unit string) *JoinedDevice {
+	return &JoinedDevice{
+		ID:          id,
+		HouseID:     houseID,
+		SetPoint:    setPoint,
+		Duration:    duration,
+		ClimateData: climateData,
+		Unit:        unit,
+	}
+}
+
 type DeviceRepository struct {
 	queries *mysqlc.Queries
 }
@@ -21,6 +41,24 @@ func (dr DeviceRepository) GetDevicesFromHouse(houseID int) ([]*domain.Device, e
 
 	devices := make([]*domain.Device, len(devicesRow))
 	for i, v := range devicesRow {
-		devices[i] = domain.NewDeviceWithID(int(v.HouseID))
+		devices[i] = domain.NewDeviceWithID(int(v.ID), int(v.HouseID), int(v.ClimateDataID), int(v.SetPoint.Int32), int(v.Duration.Int32))
 	}
+
+	return devices, nil
+}
+
+func (dr DeviceRepository) GetJoinedDevicesFromHouse(houseID int) ([]*JoinedDevice, error) {
+	ctx := context.Background()
+
+	joinedDevicesRow, err := dr.queries.GetJoinedDevicesFromHouse(ctx, int32(houseID))
+	if err != nil {
+		return nil, err
+	}
+
+	joinedDevices := make([]*JoinedDevice, len(joinedDevicesRow))
+	for i, v := range joinedDevicesRow {
+		joinedDevices[i] = NewJoinedDevice(int(v.ID), int(v.HouseID), int(v.SetPoint.Int32), int(v.Duration.Int32), v.ClimateDataName, v.Unit)
+	}
+
+	return joinedDevices, nil
 }

--- a/backend/internal/usecase/service/device.go
+++ b/backend/internal/usecase/service/device.go
@@ -2,17 +2,29 @@ package service
 
 import (
 	"github.com/Fumiya-Tahara/uecs-navi.git/internal/domain"
+	"github.com/Fumiya-Tahara/uecs-navi.git/internal/usecase/repository"
 )
 
 type DeviceService struct {
 	deviceRepository DeviceRepositoryInterface
 }
 
-func (ds DeviceService) GetDevicesFromHouse(houseID int) ([]*domain.Device, error) {
+// デバイスのみを取得するメソッド
+func (ds DeviceService) GetDevices(houseID int) ([]*domain.Device, error) {
 	devices, err := ds.deviceRepository.GetDevicesFromHouse(houseID)
 	if err != nil {
 		return nil, err
 	}
 
-	return devices, err
+	return devices, nil
+}
+
+// デバイスと気象データを1セットとして取得するメソッド
+func (ds DeviceService) GetJoinedDevices(houseID int) ([]*repository.JoinedDevice, error) {
+	joinedDevices, err := ds.deviceRepository.GetJoinedDevicesFromHouse(houseID)
+	if err != nil {
+		return nil, err
+	}
+
+	return joinedDevices, nil
 }

--- a/backend/internal/usecase/service/interfaces.go
+++ b/backend/internal/usecase/service/interfaces.go
@@ -1,11 +1,15 @@
 package service
 
-import "github.com/Fumiya-Tahara/uecs-navi.git/internal/domain"
+import (
+	"github.com/Fumiya-Tahara/uecs-navi.git/internal/domain"
+	"github.com/Fumiya-Tahara/uecs-navi.git/internal/usecase/repository"
+)
 
 type (
 	// Repository interfaces
 	DeviceRepositoryInterface interface {
 		GetDevicesFromHouse(houseID int) ([]*domain.Device, error)
+		GetJoinedDevicesFromHouse(houseID int) ([]*repository.JoinedDevice, error)
 	}
 
 	// HouseRepositoryInterface interface {


### PR DESCRIPTION
### Issue へのリンク
#14 

## 概要
デバイスデータをGETするユースケースのコードを追加しました。
ユースケース用に一つデバイスと気象データを同時に格納するための、JoinedDeviceという構造体を追加しました。特定のユースケースでしか使わないと思い、ドメインに追加するのも違うと思ったのでユースケース専用の構造体にしています。また、ユースケースをserviceとrepositoryに分けているのですが、テストようにデータを操作するのは大変なので、serviceではinterfaceとしてrepositoryを受け取るようにしています。今後のissueでテスト用のrepositoryコードを追加します。
## やったこと

- [ ]
- [ ] 動作確認とセルフレビュー


## レビューしてほしい点

- serviceがinterfaceとしてrepositoryを受け取っている点
- repositoryにユースケース専用の構造体を追加している点


## 共有事項

## 参考にしたサイト
