### PR TITLE
Rename GetAllHouse to GetAllHouses

### DIFF
--- a/backend/db/query/houses.sql
+++ b/backend/db/query/houses.sql
@@ -1,4 +1,4 @@
--- name: GetAllHouse :many
+-- name: GetAllHouses :many
 SELECT * FROM houses;
 
 -- name: CreateHouse :execlastid

--- a/backend/internal/infrastructure/orm/mysqlc/houses.sql.go
+++ b/backend/internal/infrastructure/orm/mysqlc/houses.sql.go
@@ -22,12 +22,12 @@ func (q *Queries) CreateHouse(ctx context.Context, name string) (int64, error) {
 	return result.LastInsertId()
 }
 
-const getAllHouse = `-- name: GetAllHouse :many
+const getAllHouses = `-- name: GetAllHouses :many
 SELECT id, name, created_at, updated_at FROM houses
 `
 
-func (q *Queries) GetAllHouse(ctx context.Context) ([]House, error) {
-	rows, err := q.db.QueryContext(ctx, getAllHouse)
+func (q *Queries) GetAllHouses(ctx context.Context) ([]House, error) {
+	rows, err := q.db.QueryContext(ctx, getAllHouses)
 	if err != nil {
 		return nil, err
 	}

--- a/backend/internal/usecase/repository/house.go
+++ b/backend/internal/usecase/repository/house.go
@@ -17,10 +17,10 @@ func NewHouseRepository(queries *mysqlc.Queries) *HouseRepository {
 	}
 }
 
-func (hr HouseRepository) GetAllHouse() ([]*domain.House, error) {
+func (hr HouseRepository) GetAllHouses() ([]*domain.House, error) {
 	ctx := context.Background()
 
-	housesRow, err := hr.queries.GetAllHouse(ctx)
+	housesRow, err := hr.queries.GetAllHouses(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/backend/internal/usecase/service/house.go
+++ b/backend/internal/usecase/service/house.go
@@ -15,7 +15,7 @@ func NewHouseService(hr HouseRepositoryInterface) *HouseService {
 }
 
 func (hr HouseService) GetHouses() ([]*domain.House, error) {
-	houses, err := hr.houseRepository.GetAllHouse()
+	houses, err := hr.houseRepository.GetAllHouses()
 	if err != nil {
 		return nil, err
 	}

--- a/backend/internal/usecase/service/interfaces.go
+++ b/backend/internal/usecase/service/interfaces.go
@@ -13,7 +13,7 @@ type (
 	}
 
 	HouseRepositoryInterface interface {
-		GetAllHouse() ([]*domain.House, error)
+		GetAllHouses() ([]*domain.House, error)
 	}
 
 	// ClimateDataRepositoryInterface interface {


### PR DESCRIPTION
### Issue へのリンク

#40 

## 概要
メソッド名GetAllHouseをGetAllHousesに変更

## やったこと

- [ ]
- [x] 動作確認とセルフレビュー


## レビューしてほしい点

- ちゃんと変更できているか


## 共有事項

## 参考にしたサイト


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
	- 複数の家のレコードを取得するためのメソッド名を「GetAllHouses」に変更しました。これにより、機能の明確さと一貫性が向上しました。

- **バグ修正**
	- なし

- **ドキュメント**
	- なし

- **リファクタリング**
	- コード内のメソッド名や定数名を「GetAllHouse」から「GetAllHouses」に変更しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->