### PR TITLE
Add the part to describe the page content

### DIFF
--- a/frontend/src/components/sidebar.tsx
+++ b/frontend/src/components/sidebar.tsx
@@ -12,10 +12,8 @@ const drawerWidth = 240;
 
 const SideBar = () => {
   const ListItems: string[] = [
-    "項目1",
-    "項目2",
-    "項目3",
-    "項目4",
+    "ハウス状態",
+    "デバイス設定",
   ]
 
   return (

--- a/frontend/src/layouts/navigation.tsx
+++ b/frontend/src/layouts/navigation.tsx
@@ -1,15 +1,21 @@
+import { Box, Toolbar, CssBaseline } from "@mui/material";
 import { ThemeProvider } from "@mui/material/styles";
 import Header from "../components/header";
 import Sidebar from "../components/sidebar";
 import { uecsTheme } from "../styles/theme";
 
-export function Navigation() {
+export function Navigation({ children }: { children: React.ReactNode }) {
   return (
-    <>
-      <ThemeProvider theme={uecsTheme}>
+    <ThemeProvider theme={uecsTheme}>
+      <Box sx={{ display: "flex" }}>
+        <CssBaseline />
         <Header></Header>
         <Sidebar></Sidebar>
-      </ThemeProvider>
-    </>
+        <Box component="main" sx={{ flexGrow: 1, padding: 3 }}>
+            <Toolbar />
+            {children}
+        </Box>
+      </Box>
+    </ThemeProvider>
   );
 }


### PR DESCRIPTION
### Issue へのリンク

#49 

## 概要
ナビゲーションのヘッダー、サイドバーとページの内容が被らないように、Navigationにページの内容を記述する部分を追加した。

## やったこと

- [ ]
- [x] 動作確認とセルフレビュー


## レビューしてほしい点

- 不要なcss、要素はないか


## 共有事項
ページの内容がスクロールできる程大きな場合の動作確認はしていません。

## 参考にしたサイト


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - サイドバーのリストアイテムを「ハウス状態」と「デバイス設定」に更新し、ユーザーに新しいオプションを提供。
  - ナビゲーションコンポーネントが子要素を受け取るように変更され、レイアウトが改善されました。

- **バグ修正**
  - 特になし。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->