### PR TITLE
fix create device usecase

### DIFF
--- a/backend/internal/usecase/repository/device.go
+++ b/backend/internal/usecase/repository/device.go
@@ -38,7 +38,14 @@ func NewDeviceRepository(queries *mysqlc.Queries) *DeviceRepository {
 	}
 }
 
-func (dr DeviceRepository) CreateDevice(newDevice domain.Device) (int64, error) {
+type CreateDeviceStruct struct {
+	HouseID       int
+	ClimateDataID int
+	SetPoint      int
+	Duration      int
+}
+
+func (dr DeviceRepository) CreateDevice(newDevice CreateDeviceStruct) (int64, error) {
 	ctx := context.Background()
 
 	arg := mysqlc.CreateDeviceParams{

--- a/backend/internal/usecase/service/device.go
+++ b/backend/internal/usecase/service/device.go
@@ -15,7 +15,7 @@ func NewDeviceService(dr DeviceRepositoryInterface) *DeviceService {
 	}
 }
 
-func (ds DeviceService) CreateDevice(newDevice domain.Device) (int64, error) {
+func (ds DeviceService) CreateDevice(newDevice repository.CreateDeviceStruct) (int64, error) {
 	id, err := ds.deviceRepository.CreateDevice(newDevice)
 	if err != nil {
 		return 0, err

--- a/backend/internal/usecase/service/interfaces.go
+++ b/backend/internal/usecase/service/interfaces.go
@@ -8,7 +8,7 @@ import (
 type (
 	// Repository interfaces
 	DeviceRepositoryInterface interface {
-		CreateDevice(newDevice domain.Device) (int64, error)
+		CreateDevice(newDevice repository.CreateDeviceStruct) (int64, error)
 		GetDevicesFromHouse(houseID int) ([]*domain.Device, error)
 		GetJoinedDevicesFromHouse(houseID int) ([]*repository.JoinedDevice, error)
 	}


### PR DESCRIPTION
### Issue へのリンク

#54 

## 概要
CreateDevice呼び出し時にIDが必要となる引数となっていたため変更する


## やったこと

- [x] usecase/repositotyにCreateDeviceStructの追加
- [x] repository, serviceのCreateDeviceの引数をdomain.Deviceからrepository.CreateDeviceStructに変更


## レビューしてほしい点

- CreateDeviceStuructの位置はrepositoryで問題ないか
- 変更に誤りがないか


## 共有事項

## 参考にしたサイト


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - デバイス作成のための新しいパラメータ構造体 `CreateDeviceStruct` を導入し、デバイス作成メソッドの引数を更新しました。

- **バグ修正**
  - なし

- **ドキュメント**
  - なし

- **リファクタリング**
  - デバイスリポジトリおよびサービスのメソッドシグネチャを変更しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->