### PR TITLE
46 add setting device page

### DIFF
--- a/frontend/src/components/setting-device.tsx
+++ b/frontend/src/components/setting-device.tsx
@@ -1,0 +1,172 @@
+import { 
+  Card,
+  CardActions,
+  CardContent,
+  Button,
+  Box,
+  Typography,
+  Modal,
+  TextField,
+  InputAdornment,
+  Slider,
+  FormControlLabel,
+  Switch,
+  Collapse,
+} from "@mui/material";
+import { useState } from "react";
+
+interface DeviceProps {
+  name: string;
+  setPoint?: number;
+  duration?: number;
+  climateData: string;
+  unit: string;
+}
+
+export function DeviceCard(props: DeviceProps) {
+  const {name, setPoint, duration, climateData, unit} = props;
+
+  return (
+    <Card raised={true} sx={{ minWidth: 275 }}>
+      <CardContent>
+        <Typography gutterBottom sx={{ color: 'text.main' }}>
+          {name}
+        </Typography>
+        <Box>
+          <Typography gutterBottom sx={{mt: 2, color: 'text.secondary' }}>
+            設定{climateData}
+          </Typography>
+          <Box sx={{ display: "flex", justifyContent: "center" }}>
+            <Typography variant="h4" component="div">
+              {setPoint !== undefined ? `${setPoint}` : `--`}
+            </Typography>
+            <Typography sx={{pb: 1, color: "text.secondary", alignSelf: "flex-end" }}>
+              {unit}
+            </Typography>
+          </Box>
+        </Box>
+        {duration !== undefined && (
+          <Box sx={{ mt: 2, display: "flex", alignItems: "center" }}>
+            <Typography component="span" sx={{ color: 'text.secondary' }}>
+              残り動作時間
+            </Typography>
+            <Typography component="span" sx={{ ml: 3, mr: 1 }}>
+              {duration}
+            </Typography>
+            <Typography component="span" sx={{ color: "text.secondary" }}>
+              時間
+            </Typography>
+          </Box>
+        )}
+        {/* <Typography sx={{mt: 2, color: 'text.secondary', mb: 1.5 }}>動作中</Typography> */}
+      </CardContent>
+      <CardActions>
+        <SettingModalButton
+          name={name} 
+          setPoint={setPoint} 
+          duration={duration}
+          climateData={climateData}
+          unit={unit}
+        />
+      </CardActions>
+  </Card>
+  )
+}
+
+const modalStyle = {
+  position: 'absolute',
+  top: '50%',
+  left: '50%',
+  transform: 'translate(-50%, -50%)',
+  width: 400,
+  bgcolor: 'background.paper',
+  boxShadow: 24,
+  p: 4,
+};
+
+function SettingModalButton(props: DeviceProps) {
+  const {name, setPoint, duration, climateData, unit} = props;
+  const [modalOpen, setModalOpen] = useState(false);
+  const [timerChecked, setTimerChecked] = useState(false);
+
+  const handleTimerChange = () => {
+    setTimerChecked((prev) => !prev);
+  };
+  const handleOpen = () => setModalOpen(true);
+  const handleClose = () => setModalOpen(false);
+
+  return (
+    <div>
+      <Button size="small" onClick={handleOpen}>設定</Button>
+      <Modal
+        open={modalOpen}
+        onClose={handleClose}
+        aria-labelledby="modal-modal-title"
+        aria-describedby="modal-modal-description"
+      >
+        <Box sx={modalStyle}>
+          <Typography id="modal-modal-title" variant="h6" component="h2">
+            {name}
+          </Typography>
+          <Typography sx={{ my: 2 }}>
+            <TextField
+              {...(setPoint !== undefined && { defaultValue: setPoint })}
+              type="number"
+              size="small"
+              label={`設定${climateData}`}
+              slotProps={{
+                input: {
+                  endAdornment: <InputAdornment position="end">{unit}</InputAdornment>,
+                },
+              }}
+            />
+          </Typography>
+          <Typography sx={{ my: 2 }}>
+            <FormControlLabel
+              control={<Switch checked={timerChecked} onChange={handleTimerChange} />}
+              label="タイマー"
+            />
+            <Collapse in={timerChecked}>
+              <Box sx={{ px: 3, py: 4, display: "flex", justifyContent: "center"}}>
+                <TimerSlider duration={duration} />
+              </Box>
+            </Collapse>
+          </Typography>
+          <Box sx={{mt: 4, display: "flex"}}>
+            <Button size="small">保存</Button>
+            <Button size="small">キャンセル</Button>
+          </Box>
+        </Box>
+      </Modal>
+    </div>
+  );
+}
+
+interface TimerSliderProps {
+  duration?: number;
+}
+
+export default function TimerSlider({ duration }: TimerSliderProps) {
+  const marks = [
+    { value: 1, label: "1時間" },
+    { value: 12, label: "12時間" },
+  ];
+
+  function valuetext(value: number) {
+    return `${value}時間`
+  }
+
+  return (
+    <Box sx={{ width: 300 }}>
+      <Slider
+        defaultValue={duration !== undefined ? duration : 1}
+        aria-label="Always visible"
+        getAriaValueText={valuetext}
+        min={1}
+        max={12}
+        marks={marks}
+        valueLabelDisplay="on"
+      />
+    </Box>
+  );
+}

--- a/frontend/src/components/setting-device.tsx
+++ b/frontend/src/components/setting-device.tsx
@@ -160,7 +160,7 @@ export default function TimerSlider({ duration }: TimerSliderProps) {
     <Box sx={{ width: 300 }}>
       <Slider
         defaultValue={duration !== undefined ? duration : 1}
-        aria-label="Always visible"
+        aria-label="Timer duration"
         getAriaValueText={valuetext}
         min={1}
         max={12}

--- a/frontend/src/mocks/setting_device_api.ts
+++ b/frontend/src/mocks/setting_device_api.ts
@@ -18,10 +18,10 @@ export function getDevices(houseID: number): JoinedDeviceResponse[] {
         { id: 4, name: "窓開閉装置", houseID: 1, setPoint: 30, duration: 1, climateData: "気温", unit: "℃"},
     ];
     const nasuDevices: JoinedDeviceResponse[] = [
-        { id: 5, name: "ヒーター", houseID: 2, setPoint: 25, duration: 3, climateData: "気温", unit: "℃"},
-        { id: 6, name: "ミスト", houseID: 2, setPoint: 70, duration: 1, climateData: "湿度", unit: "%"},
-        { id: 7, name: "二酸化炭素供給装置", houseID: 2, setPoint: 420, duration: 5, climateData: "二酸化炭素量", unit: "ppm"},
-        { id: 8, name: "窓開閉装置", houseID: 2, setPoint: 30, duration: 1, climateData: "気温", unit: "℃"},
+        { id: 5, name: "ヒーター", houseID: 2, setPoint: 25, duration: undefined, climateData: "気温", unit: "℃"},
+        { id: 6, name: "ミスト", houseID: 2, setPoint: 60, duration: undefined, climateData: "湿度", unit: "%"},
+        { id: 7, name: "二酸化炭素供給装置", houseID: 2, setPoint: undefined, duration: undefined, climateData: "二酸化炭素量", unit: "ppm"},
+        { id: 8, name: "窓開閉装置", houseID: 2, setPoint: undefined, duration: undefined, climateData: "気温", unit: "℃"},
     ];
     const hourensouDevices: JoinedDeviceResponse[] = [
         { id: 9, name: "テストデバイス1", houseID: 3, setPoint: 25, duration: 3, climateData: "気温", unit: "℃"},

--- a/frontend/src/mocks/setting_device_api.ts
+++ b/frontend/src/mocks/setting_device_api.ts
@@ -1,0 +1,46 @@
+import { HouseResponse, JoinedDeviceResponse } from "../types/api";
+
+export function getHouses(): HouseResponse[] {
+    const houses: HouseResponse[] = [
+        { id: 1, name: "トマトハウス" },
+        { id: 2, name: "ナスハウス" },
+        { id: 3, name: "ほうれん草ハウス" },
+    ];
+
+    return houses;
+}
+
+export function getDevices(houseID: number): JoinedDeviceResponse[] {
+    const tomatoDevices: JoinedDeviceResponse[] = [
+        { id: 1, name: "ヒーター", houseID: 1, setPoint: 25, duration: 3, climateData: "気温", unit: "℃"},
+        { id: 2, name: "ミスト", houseID: 1, setPoint: 70, duration: 1, climateData: "湿度", unit: "%"},
+        { id: 3, name: "二酸化炭素供給装置", houseID: 1, setPoint: 420, duration: 5, climateData: "二酸化炭素量", unit: "ppm"},
+        { id: 4, name: "窓開閉装置", houseID: 1, setPoint: 30, duration: 1, climateData: "気温", unit: "℃"},
+    ];
+    const nasuDevices: JoinedDeviceResponse[] = [
+        { id: 5, name: "ヒーター", houseID: 2, setPoint: 25, duration: 3, climateData: "気温", unit: "℃"},
+        { id: 6, name: "ミスト", houseID: 2, setPoint: 70, duration: 1, climateData: "湿度", unit: "%"},
+        { id: 7, name: "二酸化炭素供給装置", houseID: 2, setPoint: 420, duration: 5, climateData: "二酸化炭素量", unit: "ppm"},
+        { id: 8, name: "窓開閉装置", houseID: 2, setPoint: 30, duration: 1, climateData: "気温", unit: "℃"},
+    ];
+    const hourensouDevices: JoinedDeviceResponse[] = [
+        { id: 9, name: "テストデバイス1", houseID: 3, setPoint: 25, duration: 3, climateData: "気温", unit: "℃"},
+        { id: 10, name: "テストデバイス2", houseID: 3, setPoint: 70, duration: 1, climateData: "湿度", unit: "%"},
+        { id: 11, name: "テストデバイス3", houseID: 3, setPoint: 420, duration: 5, climateData: "二酸化炭素量", unit: "ppm"},
+        { id: 12, name: "テストデバイス4", houseID: 3, setPoint: 30, duration: 1, climateData: "気温", unit: "℃"},
+        { id: 13, name: "テストデバイス5", houseID: 3, setPoint: 25, duration: 3, climateData: "気温", unit: "℃"},
+        { id: 14, name: "テストデバイス6", houseID: 3, setPoint: 70, duration: 1, climateData: "湿度", unit: "%"},
+        { id: 15, name: "テストデバイス7", houseID: 3, setPoint: 420, duration: 5, climateData: "二酸化炭素量", unit: "ppm"},
+        { id: 16, name: "テストデバイス8", houseID: 3, setPoint: 30, duration: 1, climateData: "気温", unit: "℃"},
+    ];
+
+    const deviceMap: Map<number, JoinedDeviceResponse[]> = new Map();
+
+    deviceMap.set(1, tomatoDevices);
+    deviceMap.set(2, nasuDevices);
+    deviceMap.set(3, hourensouDevices);
+
+    const result: JoinedDeviceResponse[] = deviceMap.get(houseID) || [];
+
+    return result
+} 

--- a/frontend/src/pages/setting-device.tsx
+++ b/frontend/src/pages/setting-device.tsx
@@ -30,8 +30,8 @@ function SettingDeviceTabPanel(props: TabPanelProps) {
 
 function a11yProps(index: number) {
   return {
-    id: `simple-tab-${index}`,
-    'aria-controls': `simple-tabpanel-${index}`,
+    id: `setting-device-tabpanel-${index}`,
+    "aria-controls": `setting-device-tabpanel-${index}`,
   };
 }
 

--- a/frontend/src/pages/setting-device.tsx
+++ b/frontend/src/pages/setting-device.tsx
@@ -74,7 +74,13 @@ export default function SettingDevice() {
               <Grid container spacing={4}>
                 {devicesMap.get(house.id)?.map((device, deviceIndex) => (
                   <Grid size={3} key={deviceIndex}>
-                    <DeviceCard />
+                    <DeviceCard 
+                      name={device.name} 
+                      setPoint={device.setPoint} 
+                      duration={device.duration}
+                      climateData={device.climateData}
+                      unit={device.unit}
+                    />
                   </Grid>
                 ))}
               </Grid>

--- a/frontend/src/pages/setting-device.tsx
+++ b/frontend/src/pages/setting-device.tsx
@@ -1,0 +1,85 @@
+import { DeviceCard } from "../components/setting-device"
+import { Navigation } from "../layouts/navigation"
+import { Box, Tabs, Tab } from "@mui/material"
+import Grid from "@mui/material/Grid2";
+import { useState, useEffect } from "react";
+import { HouseResponse, JoinedDeviceResponse } from "../types/api";
+import { getDevices, getHouses } from "../mocks/setting_device_api";
+
+interface TabPanelProps {
+  children?: React.ReactNode;
+  index: number;
+  value: number;
+}
+
+function SettingDeviceTabPanel(props: TabPanelProps) {
+  const { children, value, index, ...other } = props;
+
+  return (
+    <div
+      role="tabpanel"
+      hidden={value !== index}
+      id={`setting-device-tabpanel-${index}`}
+      aria-labelledby={`setting-device-tab-${index}`}
+      {...other}
+    >
+      {value === index && <Box sx={{ p: 3 }}>{children}</Box>}
+    </div>
+  );
+}
+
+function a11yProps(index: number) {
+  return {
+    id: `simple-tab-${index}`,
+    'aria-controls': `simple-tabpanel-${index}`,
+  };
+}
+
+export default function SettingDevice() {
+  const [houses, setHouses] = useState<HouseResponse[]>([]);
+  const [devicesMap, setDevicesMap] = useState<Map<number, JoinedDeviceResponse[]>>(new Map());
+  
+  const [value, setValue] = useState(0);
+
+  useEffect(() => {
+    const housesRes: HouseResponse[] = getHouses();
+    
+
+    // 複数のハウスIDから同時にdeviceを取得するAPIを用意するべき
+    const devicesMap: Map<number, JoinedDeviceResponse[]> = new Map();
+    housesRes.forEach((house) => {
+      const devicesRes: JoinedDeviceResponse[] = getDevices(house.id);
+      devicesMap.set(house.id, devicesRes);
+    })
+
+    setHouses(housesRes);
+    setDevicesMap(devicesMap);
+  }, []);
+
+  const handleChange = (event: React.SyntheticEvent, newValue: number) => {
+    setValue(newValue);
+  };
+
+  return (
+      <Navigation>
+        <Box sx={{ borderBottom: 1, borderColor: 'divider' }}>
+          <Tabs value={value} onChange={handleChange} aria-label="basic tabs example">
+            {houses.map((house, index) => (
+              <Tab key={index} label={house.name} {...a11yProps(index)}/>
+            ))}
+          </Tabs>
+        </Box>
+          {houses.map((house, index) => (
+            <SettingDeviceTabPanel key={index} index={index} value={value}>
+              <Grid container spacing={4}>
+                {devicesMap.get(house.id)?.map((device, deviceIndex) => (
+                  <Grid size={3} key={deviceIndex}>
+                    <DeviceCard />
+                  </Grid>
+                ))}
+              </Grid>
+            </SettingDeviceTabPanel>
+          ))}
+      </Navigation>
+  )
+}

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -1,0 +1,14 @@
+export interface HouseResponse {
+    id: number;
+    name: string;
+}
+
+export interface JoinedDeviceResponse {
+    id: number;
+    name: string;
+    houseID: number;
+    setPoint?: number;
+    duration?: number;
+    climateData: string;
+    unit: string;
+}


### PR DESCRIPTION
### Issue へのリンク

#46

## 概要
デバイス選択ページの見た目部分を追加した。デザインは今後調整する予定。

## やったこと

- [ ]
- [x] 動作確認とセルフレビュー


## レビューしてほしい点

- 絶妙にダサいデザインを改善する案がないか


## 共有事項

## 参考にしたサイト


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **新機能**
  - デバイス設定を表示する新しいコンポーネント「DeviceCard」を追加。
  - 複数の家のデバイスを管理するためのタブインターフェース「SettingDevice」を実装。
  - 各デバイスの設定を調整するためのモーダル「SettingModalButton」を追加。

- **バグ修正**
  - なし

- **ドキュメント**
  - 新しいインターフェース「HouseResponse」と「JoinedDeviceResponse」を追加。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->