### PR TITLE
fix openapi CreateDevice schema

### DIFF
--- a/backend/internal/controller/dto.go
+++ b/backend/internal/controller/dto.go
@@ -1,5 +1,9 @@
 package controller
 
+type CreateHouseController struct {
+	Name string `json:"name" binding:"required,min=1,max=12,alphanum"`
+}
+
 type CreateDeviceController struct {
 	ClimateDataID int     `json:"climate_data_id" binding:"required,number"`
 	DeviceName    string  `json:"device_name" binding:"min=1,max=12"`

--- a/backend/internal/controller/dto.go
+++ b/backend/internal/controller/dto.go
@@ -1,0 +1,8 @@
+package controller
+
+type CreateDeviceController struct {
+	ClimateDataID int     `json:"climate_data_id" binding:"required,number"`
+	DeviceName    string  `json:"device_name" binding:"min=1,max=12"`
+	SetPoint      float64 `json:"set_point" binding:"number"`
+	Duration      int     `json:"duration" binding:"number"`
+}

--- a/backend/internal/controller/generated/openapi.gen.go
+++ b/backend/internal/controller/generated/openapi.gen.go
@@ -13,20 +13,21 @@ import (
 
 // DeviceRequest defines model for DeviceRequest.
 type DeviceRequest struct {
-	ClimateData *string `json:"climate_data,omitempty"`
-	DeviceName  *string `json:"device_name,omitempty"`
-	Duration    *int    `json:"duration"`
-	HouseId     *int    `json:"house-id,omitempty"`
-	Unit        *string `json:"unit,omitempty"`
+	ClimateData *string  `json:"climate_data,omitempty"`
+	DeviceName  *string  `json:"device_name,omitempty"`
+	Duration    *int     `json:"duration"`
+	SetPoint    *float64 `json:"set_point,omitempty"`
+	Unit        *string  `json:"unit,omitempty"`
 }
 
 // DeviceResponse defines model for DeviceResponse.
 type DeviceResponse struct {
-	ClimateData *string `json:"climate_data,omitempty"`
-	DeviceName  *string `json:"device_name,omitempty"`
-	Duration    *int    `json:"duration,omitempty"`
-	Id          *int    `json:"id,omitempty"`
-	Unit        *string `json:"unit,omitempty"`
+	ClimateData *string  `json:"climate_data,omitempty"`
+	DeviceName  *string  `json:"device_name,omitempty"`
+	Duration    *int     `json:"duration,omitempty"`
+	Id          *int     `json:"id,omitempty"`
+	SetPoint    *float64 `json:"set_point,omitempty"`
+	Unit        *string  `json:"unit,omitempty"`
 }
 
 // HousesRequest defines model for HousesRequest.
@@ -59,7 +60,7 @@ type ServerInterface interface {
 	// (GET /houses/{house-id})
 	GetDevice(c *gin.Context, houseId HouseId)
 	// Create device
-	// (POST /houses/{house-id})
+	// (POST /houses/{house-id}/devices)
 	CreateDevice(c *gin.Context, houseId HouseId)
 }
 
@@ -176,5 +177,5 @@ func RegisterHandlersWithOptions(router gin.IRouter, si ServerInterface, options
 	router.GET(options.BaseURL+"/houses", wrapper.GetHouses)
 	router.POST(options.BaseURL+"/houses", wrapper.CreateHouse)
 	router.GET(options.BaseURL+"/houses/:house-id", wrapper.GetDevice)
-	router.POST(options.BaseURL+"/houses/:house-id", wrapper.CreateDevice)
+	router.POST(options.BaseURL+"/houses/:house-id/devices", wrapper.CreateDevice)
 }

--- a/backend/internal/controller/handler.go
+++ b/backend/internal/controller/handler.go
@@ -65,13 +65,6 @@ func (h Handler) GetDevice(c *gin.Context, houseId int) {
 	c.JSON(http.StatusOK, devices)
 }
 
-type CreateDeviceController struct {
-	HouseID       int     `json:"house_id" binding:"required,number"`
-	ClimateDataID int     `json:"climate_data_id" binding:"required,number"`
-	SetPoint      float64 `json:"setpoint" binding:"number"`
-	Duration      int     `json:"duration" binding:"number"`
-}
-
 func (h Handler) CreateDevice(c *gin.Context, houseId int) {
 	var json CreateDeviceController
 	if err := c.BindJSON(&json); err != nil {
@@ -80,8 +73,9 @@ func (h Handler) CreateDevice(c *gin.Context, houseId int) {
 		return
 	}
 	device := domain.Device{
-		HouseID:       json.HouseID,
+		HouseID:       houseId,
 		ClimateDataID: json.ClimateDataID,
+		DeviceName:    json.DeviceName,
 		SetPoint:      json.SetPoint,
 		Duration:      json.Duration,
 	}

--- a/backend/internal/controller/handler.go
+++ b/backend/internal/controller/handler.go
@@ -31,10 +31,6 @@ func (h Handler) GetHouses(c *gin.Context) {
 	c.JSON(http.StatusOK, houses)
 }
 
-type CreateHouseController struct {
-	Name string `json:"name" binding:"required,min=1,max=12,alphanum"`
-}
-
 func (h Handler) CreateHouse(c *gin.Context) {
 	var json CreateHouseController
 	if err := c.BindJSON(&json); err != nil {

--- a/backend/openapi/openapi.yml
+++ b/backend/openapi/openapi.yml
@@ -49,6 +49,9 @@ paths:
                 type: array
                 items:
                   $ref: "#/components/schemas/DeviceResponse"
+  /houses/{house-id}/devices:
+    parameters:
+      - $ref: "#/components/parameters/house-id"
     post:
       operationId: createDevice
       tags:
@@ -78,14 +81,15 @@ components:
     DeviceRequest:
       type: object
       properties:
-        house-id:
-          type: integer
         device_name:
           type: string
         climate_data:
           type: string
         unit:
           type: string
+        set_point:
+          type: number
+          format: double
         duration:
           type: integer
           nullable: true
@@ -108,5 +112,8 @@ components:
           type: string
         unit:
           type: string
+        set_point:
+          type: number
+          format: double
         duration:
           type: integer


### PR DESCRIPTION
### Issue へのリンク

#60 

## 概要
CreateDeviceのopenapiのスキーマ修正とそれに伴う修正

## やったこと

- [ ] openapiのCreateDeviceのurlの修正とリクエストボディの修正
- [ ] openapi.gen.goの自動生成
- [ ] controllerにバリデーションの構造体を記述するdto.goを追加
- [ ] handler.goの構造体と処理の修正


## レビューしてほしい点

- コードの誤り
- 変更のし忘れがないか


## 共有事項

## 参考にしたサイト


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - デバイス作成のための新しいエンドポイント `/houses/{house-id}/devices` を追加。
  - デバイス作成時に必要な `DeviceName`、`SetPoint`、`Duration` のフィールドを含むリクエストボディをサポート。

- **変更点**
  - デバイス作成のための内部ロジックが簡素化され、コントローラー構造体が削除されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->