### PR TITLE
Create m304 demo

### DIFF
--- a/backend/internal/infrastructure/M304/send_param_demo.go
+++ b/backend/internal/infrastructure/M304/send_param_demo.go
@@ -1,0 +1,42 @@
+package m304
+
+import (
+	"fmt"
+	"net/http"
+)
+
+const (
+	addrStmn = 0x1067
+)
+
+func SendDemo(ipAddr string, sthr int, stmn int, edhr int, edmn int, inmn int, dumn int, rlyL int, rlyH int) (*http.Response, error) {
+	address := addrStmn
+	ih_sthr := ByteArrange(sthr)
+	ih_stmn := ByteArrange(stmn)
+	ih_edhr := ByteArrange(edhr)
+	ih_edmn := ByteArrange(edmn)
+	ih_inmn := ByteArrange(inmn)
+	ih_dumn := ByteArrange(dumn)
+	ih_rly_l := ByteArrange(rlyL)
+	ih_rly_h := ByteArrange(rlyH)
+	ihtxt := ih_sthr + ih_stmn + ih_edhr + ih_edmn + ih_inmn + ih_dumn + ih_rly_l + ih_rly_h
+	iht := ""
+	if len(ihtxt) < blockSize {
+		iht = ihtxt
+	} else {
+		return nil, fmt.Errorf("ihtxt length exceeds blockSize")
+	}
+	sz := Padding(fmt.Sprintf("%x", len(iht)/2), 2, "0")
+	addr := Padding(fmt.Sprintf("%x", address), 4, "0")
+	ih := ":" + sz + addr + "00" + iht + "FF"
+	// 送信処理
+	url := "http://" + ipAddr + "/" + ih
+	// fmt.Println(url)
+	resp, err := http.Get(url)
+	if err != nil {
+		return nil, err
+	}
+	resp.Body.Close()
+
+	return resp, nil
+}

--- a/backend/internal/usecase/service/m304_demo.go
+++ b/backend/internal/usecase/service/m304_demo.go
@@ -26,6 +26,11 @@ type DemoData struct {
 	Rly    []int //onにするrlyのリスト(0~7), handler.goでonじゃないものは除外
 }
 
+const (
+	inMn = 1
+	duMn = 1
+)
+
 func SettingRlyDemo(rly []int) []int {
 	rly_l := 0
 	rly_h := 0
@@ -48,8 +53,8 @@ func BuildDemoM304(demoData *DemoData) (int, error) {
 	stmn := demoData.StMn
 	edhr := demoData.EdHr
 	edmn := demoData.EdMn
-	inmn := demoData.InMn
-	dumn := demoData.DuMn
+	inmn := inMn
+	dumn := duMn
 	rly := SettingRlyDemo(demoData.Rly)
 	rly_l := rly[0]
 	rly_h := rly[1]

--- a/backend/internal/usecase/service/m304_demo.go
+++ b/backend/internal/usecase/service/m304_demo.go
@@ -1,0 +1,65 @@
+package service
+
+import (
+	"fmt"
+	"math"
+	"net/http"
+
+	m304 "github.com/Fumiya-Tahara/uecs-navi.git/internal/infrastructure/M304"
+)
+
+// m304にはあらかじめ値を入れておく
+// const (
+// 	Block    = "B"
+// 	position = 1
+// )
+
+// 初期値に従い空ならhandlerで設定
+type DemoData struct {
+	IpAddr string
+	StHr   int   //初期値0
+	StMn   int   //初期値0
+	EdHr   int   //初期値23
+	EdMn   int   //初期値59
+	InMn   int   //初期値1
+	DuMn   int   //初期値1
+	Rly    []int //onにするrlyのリスト(0~7), handler.goでonじゃないものは除外
+}
+
+func SettingRlyDemo(rly []int) []int {
+	rly_l := 0
+	rly_h := 0
+	rly_out := make([]int, 2)
+	for _, v := range rly {
+		if v < 4 {
+			rly_l += int(math.Pow(4.0, (3.0-float64(v))) * 3.0)
+		} else if v < 8 {
+			rly_h += int(math.Pow(4.0, (7.0-float64(v))) * 3.0)
+		}
+	}
+	rly_out[0] = rly_l
+	rly_out[1] = rly_h
+	return rly_out
+}
+
+func BuildDemoM304(demoData *DemoData) (int, error) {
+	ip_addr := demoData.IpAddr
+	sthr := demoData.StHr
+	stmn := demoData.StMn
+	edhr := demoData.EdHr
+	edmn := demoData.EdMn
+	inmn := demoData.InMn
+	dumn := demoData.DuMn
+	rly := SettingRlyDemo(demoData.Rly)
+	rly_l := rly[0]
+	rly_h := rly[1]
+	resp, err := m304.SendDemo(ip_addr, sthr, stmn, edhr, edmn, inmn, dumn, rly_l, rly_h)
+	if err != nil {
+		return 0, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return 0, fmt.Errorf("error in response with status code: %d", resp.StatusCode)
+	}
+	return 1, nil
+}


### PR DESCRIPTION
### Issue へのリンク
なし

## 概要
デモ用のm304送信プログラム作成

## やったこと

- [x] service/m304_demo.go, infrastructure/m304/send_param_demo.goの作成
- [x] m304での動作確認


## レビューしてほしい点

- 


## 共有事項

## 参考にしたサイト
